### PR TITLE
SelectMenu

### DIFF
--- a/components/SelectMenu.tsx
+++ b/components/SelectMenu.tsx
@@ -1,0 +1,45 @@
+import SVG from "react-inlinesvg"
+
+export type SelectMenuProps = {
+  label: React.ReactNode
+  onChange: (value: string) => void
+  value: string
+  options: {
+    label: string
+    value: string
+  }[]
+}
+/** Styled replacement for <select> */
+export const SelectMenu = ({
+  label,
+  onChange,
+  options,
+  value,
+}: SelectMenuProps) => {
+  return (
+    <label className="b2 inline-flex h-10 items-center gap-2">
+      <span className="text-gray-1">{label}:</span>
+      <div className="relative flex">
+        <select
+          className="h-10 appearance-none rounded bg-[transparent] pie-7 pis-2"
+          onChange={(e) => onChange(e.target.value)}
+        >
+          {options.map(({ label: optionLabel, value: optionValue }) => (
+            <option
+              key={optionValue}
+              value={optionValue}
+              selected={optionValue === value}
+            >
+              {optionLabel}
+            </option>
+          ))}
+        </select>
+        <SVG
+          className="absolute text-gray-1 inline-end-2 block-start-4"
+          src={"/ui/disclosure-arrow.svg"}
+        />
+      </div>
+    </label>
+  )
+}
+export default SelectMenu

--- a/components/SelectMenu.tsx
+++ b/components/SelectMenu.tsx
@@ -35,7 +35,7 @@ export const SelectMenu = ({
           ))}
         </select>
         <SVG
-          className="absolute text-gray-1 inline-end-2 block-start-4"
+          className="pointer-events-none absolute text-gray-1 inline-end-2 block-start-4"
           src={"/ui/disclosure-arrow.svg"}
         />
       </div>

--- a/pages/guide.js
+++ b/pages/guide.js
@@ -1,8 +1,11 @@
 import SVG from "react-inlinesvg"
 import loadIntlMessages from "../utils/loadIntlMessages"
 import { IconCard } from "../components/IconCard"
+import SelectMenu from "../components/SelectMenu"
+import { FormattedMessage, useIntl } from "react-intl"
 
 function Home(props) {
+  const intl = useIntl()
   return (
     <div className="flex flex-col gap-16 [padding-block:4rem]">
       <section>
@@ -91,37 +94,74 @@ function Home(props) {
           ))}
         </div>
       </section>
-      <section>
+      <section className="flex flex-col gap-8">
         <h2 className="h5">Components</h2>
 
-        <h3 className="h6">IconCard</h3>
-        <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-gutter">
-          <IconCard
-            title="Decentralized"
-            icon="decentralized"
-            copy={
-              "Not controlled by a single website or company, Mastodon is a network of completely independent service providers forming a global, cohesive social media platform. "
-            }
-          />
-          <IconCard
-            title="Open Source"
-            icon="open-source"
-            copy={
-              "Mastodon is free and open-source software. We believe in your right to use, copy, study and change Mastodon as you see fit. Community collaboration helps us continually evolve Mastodon."
-            }
-          />
-          <IconCard
-            title="Not for Sale"
-            icon="privacy"
-            copy={
-              "No surprises. Your feed is curated and created by you. We will never serve ads or push profiles for you to see. That means your data is yours and yours alone."
-            }
-          />
-          <IconCard
-            title="Privacy-Minded"
-            icon="safety"
-            copy={"You’re in control. Publish only what you choose."}
-          />
+        <div>
+          <h3 className="h6">IconCard</h3>
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-gutter">
+            <IconCard
+              title="Decentralized"
+              icon="decentralized"
+              copy={
+                "Not controlled by a single website or company, Mastodon is a network of completely independent service providers forming a global, cohesive social media platform. "
+              }
+            />
+            <IconCard
+              title="Open Source"
+              icon="open-source"
+              copy={
+                "Mastodon is free and open-source software. We believe in your right to use, copy, study and change Mastodon as you see fit. Community collaboration helps us continually evolve Mastodon."
+              }
+            />
+            <IconCard
+              title="Not for Sale"
+              icon="privacy"
+              copy={
+                "No surprises. Your feed is curated and created by you. We will never serve ads or push profiles for you to see. That means your data is yours and yours alone."
+              }
+            />
+            <IconCard
+              title="Privacy-Minded"
+              icon="safety"
+              copy={"You’re in control. Publish only what you choose."}
+            />
+          </div>
+        </div>
+        <div>
+          <h3 className="h6">IconCard</h3>
+          <div>
+            <SelectMenu
+              label={
+                <FormattedMessage id="sorting.sort_by" defaultMessage="Sort" />
+              }
+              value="all"
+              onChange={() => {}}
+              options={[
+                {
+                  label: intl.formatMessage({
+                    id: "sorting.recently_added",
+                    defaultMessage: "Recently added",
+                  }),
+                  value: "all",
+                },
+                {
+                  label: intl.formatMessage({
+                    id: "sorting.free",
+                    defaultMessage: "Free",
+                  }),
+                  value: "x",
+                },
+                {
+                  label: intl.formatMessage({
+                    id: "sorting.alphabetical",
+                    defaultMessage: "A–Z",
+                  }),
+                  value: "y",
+                },
+              ]}
+            />
+          </div>
         </div>
       </section>
     </div>

--- a/public/ui/disclosure-arrow.svg
+++ b/public/ui/disclosure-arrow.svg
@@ -1,3 +1,3 @@
 <svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1.184 4.01802L2.224 2.97002L5 5.81002L7.776 2.97002L8.816 4.01802L5 7.82602L1.184 4.01802Z" fill="white"/>
+<path d="M1.184 4.01802L2.224 2.97002L5 5.81002L7.776 2.97002L8.816 4.01802L5 7.82602L1.184 4.01802Z" fill="currentColor"/>
 </svg>


### PR DESCRIPTION
LTR:

<img width="486" alt="Screen Shot 2022-07-22 at 07 17 32" src="https://user-images.githubusercontent.com/1642599/180428670-7f1a6e6c-011f-44ab-8550-892a6157fac2.png">

and RTL (probably not the right translation):

<img width="485" alt="Screen Shot 2022-07-22 at 07 17 53" src="https://user-images.githubusercontent.com/1642599/180428504-9c159dbe-5a67-4a02-9aef-68970a23aeb5.png">

- I hardcoded the `:`, but I'm not sure if we should make it be a part of the `sort_by` translation string. it seems common across languages and scripts, with maybe some preferences in certain languages (eg. [`sort by relevance`](https://www.google.com/search?tbm=shop&hl=th&psb=1&ved=2ahUKEwit3YvFsYz5AhUUDYgJHUYECVcQu-kFegQIABAQ&q=electronic&oq=electronic&gs_lcp=Cgtwcm9kdWN0cy1jYxADUABYAGAAaABwAHgAgAEAiAEAkgEAmAEA&sclient=products-cc) in thai vs [`sort by:  relevance`](https://www.google.com/search?tbm=shop&hl=en&psb=1&ved=2ahUKEwit3YvFsYz5AhUUDYgJHUYECVcQu-kFegQIABAQ&q=electronic&oq=electronic&gs_lcp=Cgtwcm9kdWN0cy1jYxADUABYAGAAaABwAHgAgAEAiAEAkgEAmAEA&sclient=products-cc), though there's examples of the [same structure as ours](https://www.apple.com/th/shop/iphone/accessories/power-cables), so... ?)

- i think this is a pretty generic component so i named it selectmenu, but it's only used for sorting inputs ATM