### PR TITLE
updated server card design, localized number formatter

### DIFF
--- a/components/ServerCard.tsx
+++ b/components/ServerCard.tsx
@@ -6,40 +6,46 @@ import LinkButton from "./LinkButton"
 import type { Server } from "../types/api"
 
 import { categoriesMessages } from "../data/categories"
+import SVG from "react-inlinesvg"
+import { formatNumber } from "../utils/numbers"
 
 const ServerCard = ({ server }: { server: Server }) => {
   const intl = useIntl()
   return (
-    <div className="grid grid-rows-[auto_1fr_auto] rounded shadow">
-      <div className="relative h-26 rounded-t bg-black lg:h-40">
+    <div className="grid grid-rows-[auto_1fr_auto] rounded-md p-4 shadow">
+      <div className="relative h-26 overflow-hidden rounded-md bg-black lg:h-40">
         <Image
           className="rounded-t"
           src={server.proxied_thumbnail}
           layout="fill"
           objectFit="cover"
         />
+        <span className="absolute flex items-center gap-1 rounded bg-white px-1.5 py-0.5 text-gray-1 inline-end-2 block-start-2">
+          {formatNumber(server.total_users, intl.locale)}
+          <SVG src="/ui/person.svg" />
+        </span>
       </div>
 
-      <div className="p-4 pb-5">
-        <p className="b1 !font-700">{server.domain}</p>
-        <p className="b3 mb-4 capitalize text-gray-1">
-          <span
-            className={classNames(
-              server.approval_required && "after:px-1 after:content-['·']"
-            )}
-          >
+      <div className="pb-5">
+        <p className="b3 mt-4 mb-2 !font-600 uppercase text-gray-2">
+          <span>
             {server.category in categoriesMessages
               ? intl.formatMessage(categoriesMessages[server.category])
               : server.category}
           </span>
-          {server.approval_required && <span>Invite only</span>}
+          {server.approval_required && (
+            <span className="before:px-1 before:content-['·']">
+              Invite only
+            </span>
+          )}
         </p>
+        <p className="b1 mb-2 !font-700">{server.domain}</p>
         <p className="b3 line-clamp-5 [unicode-bidi:plaintext]">
           {server.description}
         </p>
       </div>
 
-      <div className="p-4 pt-0">
+      <div className="">
         <LinkButton
           href={`https://${server.domain}`}
           light={server.approval_required}

--- a/components/ServerCard.tsx
+++ b/components/ServerCard.tsx
@@ -13,9 +13,9 @@ const ServerCard = ({ server }: { server: Server }) => {
   const intl = useIntl()
   return (
     <div className="grid grid-rows-[auto_1fr_auto] rounded-md p-4 shadow">
-      <div className="relative h-26 overflow-hidden rounded-md bg-black lg:h-40">
+      <div className="relative h-26 lg:h-40">
         <Image
-          className="rounded-t"
+          className="rounded-md bg-black"
           src={server.proxied_thumbnail}
           layout="fill"
           objectFit="cover"

--- a/public/ui/person.svg
+++ b/public/ui/person.svg
@@ -1,0 +1,4 @@
+<svg width="10" height="12" viewBox="0 0 10 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle r="2.03335" transform="matrix(-1 0 0 1 4.99992 2.69936)" stroke="currentColor"/>
+<path d="M0.500061 9.83398V11.334H9.50006V9.83398C9.50006 7.3487 7.48534 5.33398 5.00006 5.33398C2.51478 5.33398 0.500061 7.3487 0.500061 9.83398Z" stroke="currentColor"/>
+</svg>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -49,9 +49,6 @@ module.exports = {
     boxShadow: {
       DEFAULT: "0px 4px 15px rgba(0, 0, 0, 0.1);",
     },
-    borderRadius: {
-      DEFAULT: "4px",
-    },
     colors: {
       black: "var(--black)",
       white: "var(--white)",

--- a/utils/numbers.ts
+++ b/utils/numbers.ts
@@ -1,0 +1,13 @@
+import { defaultLocale } from "../data/locales"
+
+export const formatNumber = (
+  number: number,
+  localeCode: string = defaultLocale,
+  options: Intl.NumberFormatOptions = {}
+): string => {
+  let intlOptions: Intl.NumberFormatOptions = {
+    notation: "compact",
+    ...options,
+  }
+  return new Intl.NumberFormat(localeCode, intlOptions).format(number)
+}


### PR DESCRIPTION
hoping to fix and improve on a bug i noticed here, too

<img width="434" alt="Screen Shot 2022-07-26 at 21 01 37" src="https://user-images.githubusercontent.com/1642599/181157932-ab6ee6ed-d216-4c52-bc03-ffe2d97bc18e.png">

the in-built `Intl` class does a pretty good job localizing (was playing with `numberingSystem` here, but won't be implementing here. the decision can be made upstream if it seems appropriate):

<img width="1133" alt="image" src="https://user-images.githubusercontent.com/1642599/181160514-2dd1ccd4-b9a5-4bf4-ab70-66622ef95a03.png">

pretty cool, but there are a few things that seem suboptimal:

- the SI abbreviations seem like a fallback for unimplemented localizations, eg. `3K` in thai should probably be `3พัน` from what i've found?
- german not abbreviating at all... seems like a joke but might be normal?? 
- level of localization varies from browser to browser

but i think this is progressive enhancement anyways

<img width="329" alt="Screen Shot 2022-07-27 at 01 13 42" src="https://user-images.githubusercontent.com/1642599/181166599-1a14beec-aee5-4fce-adf7-5a942bb1c01e.png">