### PR TITLE
Imprint

### DIFF
--- a/components/BasicPage.tsx
+++ b/components/BasicPage.tsx
@@ -1,0 +1,11 @@
+export const BasicPage = ({ children }) => {
+  return (
+    <div className="grid-cols-12 pt-[var(--header-area)] md:grid">
+      <div className="pt-16 md:col-span-10 md:col-start-2 lg:col-span-8 lg:col-start-3">
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export default BasicPage

--- a/pages/imprint.tsx
+++ b/pages/imprint.tsx
@@ -1,0 +1,53 @@
+import React from "react"
+import Helmet from "react-helmet"
+
+import Navigation from "./Navigation"
+import BottomNavigation from "./BottomNavigation"
+
+// This page does not require translations
+
+const Imprint = () => (
+  <div className="browse-apps covenant">
+    <Navigation />
+
+    <div className="container">
+      <h1>Contact us / Impressum</h1>
+      <p className="lead">
+        For the pages under joinmastodon.org and its subdomains:
+      </p>
+      <hr />
+
+      <p>
+        Mastodon gGmbH
+        <br />
+        Mühlenstraße 8a
+        <br />
+        14167 Berlin
+        <br />
+        Germany
+      </p>
+      <p>
+        E-Mail-Adresse:{" "}
+        <a href="mailto:hello@joinmastodon.org">hello@joinmastodon.org</a>
+      </p>
+      <p>Vertretungsberechtigt: Eugen Rochko (Geschäftsführer)</p>
+      <p>Umsatzsteuer Identifikationsnummer (USt-ID): DE344258260</p>
+      <p>
+        Handelsregister
+        <br />
+        Geführt bei: Amtsgericht Charlottenburg
+        <br />
+        Nummer: HRB 230086 B
+      </p>
+    </div>
+
+    <BottomNavigation />
+
+    <Helmet>
+      <title>Contact us / Impressum - Mastodon</title>
+      <meta property="og:title" content="Contact us / Impressum" />
+    </Helmet>
+  </div>
+)
+
+export default Imprint

--- a/pages/imprint.tsx
+++ b/pages/imprint.tsx
@@ -1,52 +1,63 @@
-import React from "react"
-import Helmet from "react-helmet"
-
-import Navigation from "./Navigation"
-import BottomNavigation from "./BottomNavigation"
+import Head from "next/head"
 
 // This page does not require translations
-
 const Imprint = () => (
-  <div className="browse-apps covenant">
-    <Navigation />
-
-    <div className="container">
-      <h1>Contact us / Impressum</h1>
-      <p className="lead">
+  <div className="pt-[var(--header-area)] [unicode-bidi:plaintext]">
+    <div className="py-8">
+      <h1 className="h2">Contact us / Impressum</h1>
+      <p className="sh1">
         For the pages under joinmastodon.org and its subdomains:
       </p>
-      <hr />
+      <hr className="my-4" />
+      <address className="not-italic">
+        <p>
+          Mastodon gGmbH
+          <br />
+          Mühlenstraße 8a
+          <br />
+          14167 Berlin
+          <br />
+          Germany
+        </p>
+        <dl>
+          <div>
+            <dt className="inline after:content-[':_']">E-Mail-Adresse</dt>
+            <dd className="inline">
+              <a href="mailto:hello@joinmastodon.org">hello@joinmastodon.org</a>
+            </dd>
+          </div>
+          <div>
+            <dt className="inline after:content-[':_']">
+              Vertretungsberechtigt
+            </dt>
+            <dd className="inline">Eugen Rochko (Geschäftsführer)</dd>
+          </div>
 
-      <p>
-        Mastodon gGmbH
-        <br />
-        Mühlenstraße 8a
-        <br />
-        14167 Berlin
-        <br />
-        Germany
-      </p>
-      <p>
-        E-Mail-Adresse:{" "}
-        <a href="mailto:hello@joinmastodon.org">hello@joinmastodon.org</a>
-      </p>
-      <p>Vertretungsberechtigt: Eugen Rochko (Geschäftsführer)</p>
-      <p>Umsatzsteuer Identifikationsnummer (USt-ID): DE344258260</p>
-      <p>
-        Handelsregister
-        <br />
-        Geführt bei: Amtsgericht Charlottenburg
-        <br />
-        Nummer: HRB 230086 B
-      </p>
+          <div>
+            <dt className="inline after:content-[':_']">
+              Umsatzsteuer Identifikationsnummer (USt-ID)
+            </dt>
+            <dd className="inline">DE344258260</dd>
+          </div>
+        </dl>
+        <p>Handelsregister</p>
+        <dl>
+          <div>
+            <dt className="inline after:content-[':_']">Geführt bei</dt>
+            <dd className="inline">Amtsgericht Charlottenburg</dd>
+          </div>
+          <div>
+            <dt className="inline after:content-[':_']">Nummer</dt>
+            <dd className="inline">HRB 230086 B</dd>
+          </div>
+        </dl>
+      </address>
     </div>
 
-    <BottomNavigation />
-
-    <Helmet>
+    <Head>
       <title>Contact us / Impressum - Mastodon</title>
       <meta property="og:title" content="Contact us / Impressum" />
-    </Helmet>
+    </Head>
   </div>
 )
 

--- a/pages/imprint.tsx
+++ b/pages/imprint.tsx
@@ -1,64 +1,69 @@
 import Head from "next/head"
+import BasicPage from "../components/BasicPage"
 
 // This page does not require translations
 const Imprint = () => (
-  <div className="pt-[var(--header-area)] [unicode-bidi:plaintext]">
-    <div className="py-8">
-      <h1 className="h2">Contact us / Impressum</h1>
-      <p className="sh1">
-        For the pages under joinmastodon.org and its subdomains:
-      </p>
-      <hr className="my-4" />
-      <address className="not-italic">
-        <p>
-          Mastodon gGmbH
-          <br />
-          Mühlenstraße 8a
-          <br />
-          14167 Berlin
-          <br />
-          Germany
+  <BasicPage>
+    <div className="[unicode-bidi:plaintext]">
+      <div className="py-8">
+        <h1 className="h2">Contact us / Impressum</h1>
+        <p className="sh1">
+          For the pages under joinmastodon.org and its subdomains:
         </p>
-        <dl>
-          <div>
-            <dt className="inline after:content-[':_']">E-Mail-Adresse</dt>
-            <dd className="inline">
-              <a href="mailto:hello@joinmastodon.org">hello@joinmastodon.org</a>
-            </dd>
-          </div>
-          <div>
-            <dt className="inline after:content-[':_']">
-              Vertretungsberechtigt
-            </dt>
-            <dd className="inline">Eugen Rochko (Geschäftsführer)</dd>
-          </div>
+        <hr className="my-4" />
+        <address className="not-italic">
+          <p>
+            Mastodon gGmbH
+            <br />
+            Mühlenstraße 8a
+            <br />
+            14167 Berlin
+            <br />
+            Germany
+          </p>
+          <dl>
+            <div>
+              <dt className="inline after:content-[':_']">E-Mail-Adresse</dt>
+              <dd className="inline">
+                <a href="mailto:hello@joinmastodon.org">
+                  hello@joinmastodon.org
+                </a>
+              </dd>
+            </div>
+            <div>
+              <dt className="inline after:content-[':_']">
+                Vertretungsberechtigt
+              </dt>
+              <dd className="inline">Eugen Rochko (Geschäftsführer)</dd>
+            </div>
 
-          <div>
-            <dt className="inline after:content-[':_']">
-              Umsatzsteuer Identifikationsnummer (USt-ID)
-            </dt>
-            <dd className="inline">DE344258260</dd>
-          </div>
-        </dl>
-        <p>Handelsregister</p>
-        <dl>
-          <div>
-            <dt className="inline after:content-[':_']">Geführt bei</dt>
-            <dd className="inline">Amtsgericht Charlottenburg</dd>
-          </div>
-          <div>
-            <dt className="inline after:content-[':_']">Nummer</dt>
-            <dd className="inline">HRB 230086 B</dd>
-          </div>
-        </dl>
-      </address>
+            <div>
+              <dt className="inline after:content-[':_']">
+                Umsatzsteuer Identifikationsnummer (USt-ID)
+              </dt>
+              <dd className="inline">DE344258260</dd>
+            </div>
+          </dl>
+          <p>Handelsregister</p>
+          <dl>
+            <div>
+              <dt className="inline after:content-[':_']">Geführt bei</dt>
+              <dd className="inline">Amtsgericht Charlottenburg</dd>
+            </div>
+            <div>
+              <dt className="inline after:content-[':_']">Nummer</dt>
+              <dd className="inline">HRB 230086 B</dd>
+            </div>
+          </dl>
+        </address>
+      </div>
+
+      <Head>
+        <title>Contact us / Impressum - Mastodon</title>
+        <meta property="og:title" content="Contact us / Impressum" />
+      </Head>
     </div>
-
-    <Head>
-      <title>Contact us / Impressum - Mastodon</title>
-      <meta property="og:title" content="Contact us / Impressum" />
-    </Head>
-  </div>
+  </BasicPage>
 )
 
 export default Imprint


### PR DESCRIPTION
added this page because we don't super have layout infra for generic pages

[one q i had was whether there's a default hero](https://www.figma.com/file/Wk8L4YNZvgTBcrpthCYmBj?node-id=320:562#236268490), but we can come back and touch up

also not sure if we should cover generic element styles (`hr`, `blockquote`, etc) for these pages

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/1642599/181382549-4790c9e9-d73f-416f-b928-91c526322762.png">
