### PR TITLE
SelectMenu UX

### DIFF
--- a/components/SelectMenu.tsx
+++ b/components/SelectMenu.tsx
@@ -27,13 +27,10 @@ export const SelectMenu = ({
         <select
           className="h-10 appearance-none rounded bg-[transparent] pie-7 pis-2"
           onChange={(e) => onChange(e.target.value)}
+          value={value}
         >
           {options.map(({ label: optionLabel, value: optionValue }) => (
-            <option
-              key={optionValue}
-              value={optionValue}
-              selected={optionValue === value}
-            >
+            <option key={optionValue} value={optionValue}>
               {optionLabel}
             </option>
           ))}

--- a/components/SelectMenu.tsx
+++ b/components/SelectMenu.tsx
@@ -25,7 +25,7 @@ export const SelectMenu = ({
       <span className="text-gray-1">{label}:</span>
       <div className="relative flex">
         <select
-          className="h-10 appearance-none rounded bg-[transparent] pie-7 pis-2"
+          className="h-10 cursor-pointer appearance-none rounded bg-[transparent] pie-7 pis-2 hover:bg-gray-5"
           onChange={(e) => onChange(e.target.value)}
           value={value}
         >


### PR DESCRIPTION
>On the other hand, the languages dropdown looks like text - pointer cursor might help here

rel #68, added some fine-pointer feedback to select menus

<img width="465" alt="image" src="https://user-images.githubusercontent.com/1642599/183116177-56de5a23-83ce-4b6e-a0ca-787d220f4752.png">

you'll have to trust that there's a pointer cursor there lol... the macOS screenshot tool won't show my cursor in the screenshot despite the setting for it being turned on