### PR TITLE
fixed back-button bug

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -6,8 +6,14 @@ import Header from "./Header"
 export const Layout = ({ children }) => {
   return (
     <div className="mx-auto max-w-site px-6 lg:px-16">
+      <a
+        className="sr-only top-0 left-0 z-20 block bg-dark-blurple text-white focus:not-sr-only focus:absolute focus:p-2"
+        href="#main"
+      >
+        Skip to main content
+      </a>
       <Header />
-      {children}
+      <main id="main">{children}</main>
       <Footer />
       <Head>
         <meta

--- a/components/MenuToggle.tsx
+++ b/components/MenuToggle.tsx
@@ -1,21 +1,29 @@
 import classNames from "classnames"
 import { useEffect } from "react"
 
+export type MenuToggleProps = {
+  /** Open state of the toggle, controls HTML element's overflow as well */
+  open: boolean
+  /** Toggle's button click handler */
+  onClick: () => void
+  /** Misc. attributes (eg. aria-*) */
+  attributes: React.ComponentPropsWithoutRef<"button">
+}
 /**
  * Mobile menu toggle
  * Also controls scrollability of the page
  */
-export const MenuToggle = ({ open, onClick }) => {
+export const MenuToggle = ({ open, onClick, attributes }: MenuToggleProps) => {
   useEffect(() => {
-    if (open) {
-      document.documentElement.classList.add("overflow-hidden")
-      document.documentElement.classList.add("md:overflow-auto")
-    } else {
-      document.documentElement.classList.remove("overflow-hidden")
-    }
+    document.documentElement.classList.toggle("overflow-hidden", open)
+    document.documentElement.classList.toggle("md:overflow-auto", open)
   }, [open])
   return (
-    <button onClick={onClick} className="relative z-10 md:hidden">
+    <button
+      onClick={onClick}
+      className="relative z-10 md:hidden"
+      {...attributes}
+    >
       <svg
         width="27"
         height="19"


### PR DESCRIPTION
Removed arrow-key navigation from main menu, added a skip link before it, and improved the aria attributes of the mobile menu toggle

fixes #71 by removing the [roving tabindex management](https://github.com/oakstudios/joinmastodon/compare/main...oakstudios:joinmastodon:navigation-bug?expand=1#diff-a705902108330efeeffcb3ff25696c3982c311b332b1a3d1007b70468080b5f0L244-L254) (not 100% sure why this was causing it, but it was)